### PR TITLE
Update Dockerfile 

### DIFF
--- a/docker-compose/ton-node/build/Dockerfile
+++ b/docker-compose/ton-node/build/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.51.0
+ARG RUST_VERSION=1.53.0
 
 FROM ubuntu:18.04 as build
 


### PR DESCRIPTION
I suggest to modify the rust version to 1.53.0
rustnet.ton.dev/docker-compose/ton-node/build/Dockerfile

ARG RUST_VERSION=1.53.0

Because after installing it several times, I found that 1.51.0 will freeze for more than ten minutes in the following steps.
The 1.53.0 version will not freeze,
Although I don't know the specific reason. However, this modification can save installation time.